### PR TITLE
Windows compatibility fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,10 +10,15 @@ var JSCS = path.join(__dirname, 'node_modules', '.bin', 'jscs')
 var JSCSRC = path.join(__dirname, 'lib', '.jscsrc')
 var JSCS_REPORTER = path.join(__dirname, 'lib', 'jscs-reporter.js')
 
+if (/^win/.test(process.platform)) {
+  JSHINT += '.cmd'
+  JSCS += '.cmd'
+}
+
 module.exports = function (dir) {
   find.file(/\.js$/, dir || process.cwd(), function (files) {
     files = files.filter(function (file) {
-      return !/\/node_modules\/|\/.git\/|\.min.js$|\/bundle.js$/.test(file)
+      return !/[\/\\]node_modules[\/\\]|[\/\\].git[\/\\]|\.min.js$|\/bundle.js$/.test(file)
     })
 
     var jshintArgs = ['--config', JSHINTRC, '--reporter', 'unix'].concat(files)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "url": "git://github.com/feross/standard.git"
   },
   "scripts": {
-    "test": "./bin/cmd.js"
+    "test": "node ./bin/cmd.js"
   }
 }


### PR DESCRIPTION
* child_process.spawn ignores PATHEXT on Windows, see joyent/node#2318
* find doesn't normalise path separators, added window variants to file filter RegExp
* `npm test` doesn't work on Windows with bare path to .js file