### PR TITLE
add --rcpath option

### DIFF
--- a/bin/altrc/.jshintrc
+++ b/bin/altrc/.jshintrc
@@ -1,0 +1,29 @@
+{
+  "asi": true,
+  "browser": true,
+  "devel": true,
+  "eqeqeq": true,
+  "eqnull": true,
+  "esnext": true,
+  "expr": true,
+  "globals": {
+    "chrome": false,
+    "FileList": false
+  },
+  "globalstrict": true,
+  "immed": true,
+  "latedef": "nofunc",
+  "laxbreak": true,
+  "loopfunc": true,
+  "newcap": true,
+  "noarg": true,
+  "node": true,
+  "predef": [
+    "escape",
+    "unescape"
+  ],
+  "strict": true,
+  "sub": true,
+  "undef": true,
+  "unused": "vars"
+}

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -3,7 +3,33 @@
 var minimist = require('minimist')
 var standard = require('../')
 
-var argv = minimist(process.argv.slice(2))
+var argv = minimist(process.argv.slice(2), {
+  boolean: [ 'help', 'bare', 'verbose', 'version' ],
+  alias: {
+    help: 'h',
+    verbose: 'v',
+    rcpath: 'r'
+  }
+})
+
+if (argv.help) {
+  console.log(function () {
+  /*
+  Usage:
+      standard <flags>
+
+  Flags:
+      -v, --verbose    Show error codes (so you can ignore specific rules)
+          --version    Display the current version
+      -h, --help       Display the help and usage details
+      -r, --rcpath     Provide an alternative directory of rc files
+
+  Report bugs:  https://github.com/feross/standard/issues
+
+  */
+  }.toString().split(/\n/).slice(2, -2).join('\n'))
+  process.exit(0)
+}
 
 if (argv.version) {
   console.log(require('../package.json').version)
@@ -12,7 +38,8 @@ if (argv.version) {
 
 standard({
   cwd: process.cwd(),
-  bare: argv.bare || argv.b,
-  verbose: argv.verbose || argv.v,
-  rcpath: argv.rcpath || argv.r
+  bare: argv.bare,
+  stdin: !process.stdin.isTTY,
+  verbose: argv.verbose,
+  rcpath: argv.rcpath
 })

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,16 +1,18 @@
 #!/usr/bin/env node
 
+var minimist = require('minimist')
 var standard = require('../')
 
-var flag = process.argv[2]
+var argv = minimist(process.argv.slice(2))
 
-if (flag === '--version') {
+if (argv.version) {
   console.log(require('../package.json').version)
   process.exit(0)
 }
 
 standard({
   cwd: process.cwd(),
-  bare: flag === '--bare' || flag === '-b',
-  verbose: flag === '--verbose' || flag === '-v'
+  bare: argv.bare || argv.b,
+  verbose: argv.verbose || argv.v,
+  rcpath: argv.rcpath || argv.r
 })

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -22,7 +22,11 @@ if (argv.help) {
       -v, --verbose    Show error codes (so you can ignore specific rules)
           --version    Display the current version
       -h, --help       Display the help and usage details
+<<<<<<< HEAD
       -r, --rcpath     Provide an alternative directory of rc files
+=======
+      -r  --rcpath     Provide an alternate directory of .rc files
+>>>>>>> d0529a6... add --rcpath option
 
   Report bugs:  https://github.com/feross/standard/issues
 

--- a/bin/test.js
+++ b/bin/test.js
@@ -23,6 +23,7 @@ var urls = [
   'https://github.com/feross/bittorrent-tracker.git',
   'https://github.com/feross/bittorrent-dht.git',
   'https://github.com/feross/buffer.git',
+  'https://github.com/feross/studynotes.git',
   'https://github.com/mafintosh/level-temp.git'
 ]
 

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ var cp = require('child_process')
 var findRoot = require('find-root')
 var glob = require('glob')
 var Minimatch = require('minimatch').Minimatch
+var parallel = require('run-parallel')
 var path = require('path')
 var split = require('split')
 var fs = require('fs')
@@ -38,7 +39,16 @@ var FILE_RE = /(.*?):/
 var LINE_RE = /.*?:(\d+)/
 var COL_RE = /.*?:\d+:(\d+)/
 
-module.exports = function (opts) {
+/**
+ * JavaScript Standard Style
+ * @param {Object} opts                        options object
+ * @param {string|Array.<String>} opts.ignore  files to ignore
+ * @param {string} opts.cwd                    current working directory
+ * @param {boolean} opts.verbose               show error codes
+ * @param {boolean} opts.bare                  show raw linter output (for debugging)
+ * @param {boolean} opts.stdin                 check text from stdin instead of filesystem
+ */
+module.exports = function standard (opts) {
   if (!opts) opts = {}
   var errors = []
 
@@ -54,7 +64,7 @@ module.exports = function (opts) {
     if (packageOpts) ignore = ignore.concat(packageOpts.ignore)
   }
 
-  if (opts.ignore) ignore = ignore.concat(opts.ignore)
+  var jshintArgs = ['--config', JSHINT_RC, '--reporter', JSHINT_REPORTER]
 
   var rcpath = opts.rcpath || DEFAULT_RCPATH
   var jshintPath = usePathOrFallback(rcpath, JSHINT_RC)
@@ -81,23 +91,54 @@ module.exports = function (opts) {
     var eslintReporter = opts.verbose ? ESLINT_REPORTER_VERBOSE : ESLINT_REPORTER
     var eslintArgs = ['--config', eslintPath, '--format', eslintReporter]
 
-    if (opts.verbose) {
-      jshintArgs.push('--verbose')
-      jscsArgs.push('--verbose')
-    }
+  var eslintReporter = opts.verbose ? ESLINT_REPORTER_VERBOSE : ESLINT_REPORTER
+  var eslintArgs = ['--config', ESLINT_RC, '--format', eslintReporter]
+>>>>>>> 175eb77... Support stdin [usage: standard < file.js]
 
-    jshintArgs = jshintArgs.concat(files)
-    jscsArgs = jscsArgs.concat(files)
-    eslintArgs = eslintArgs.concat(files)
+  if (opts.verbose) {
+    jshintArgs.push('--verbose')
+    jscsArgs.push('--verbose')
+  }
 
-    spawn(JSHINT, jshintArgs, function (err1) {
-      spawn(JSCS, jscsArgs, function (err2) {
-        spawn(ESLINT, eslintArgs, function (err3) {
-          done(err1 || err2 || err3)
+  if (opts.stdin) {
+    // stdin
+    jshintArgs.push('-')
+    eslintArgs.push('--stdin')
+    lint()
+  } else {
+    // traverse filesystem
+    if (opts.ignore) ignore = ignore.concat(opts.ignore)
+
+    ignore = ignore.map(function (pattern) {
+      return new Minimatch(pattern)
+    })
+
+    glob('**/*.js', {
+      cwd: opts.cwd || process.cwd()
+    }, function (err, files) {
+      if (err) return error(err)
+      files = files.filter(function (file) {
+        return !ignore.some(function (mm) {
+          return mm.match(file)
         })
       })
+      jshintArgs = jshintArgs.concat(files)
+      jscsArgs = jscsArgs.concat(files)
+      eslintArgs = eslintArgs.concat(files)
+      lint()
     })
-  })
+  }
+
+  function lint () {
+    parallel([
+      spawn.bind(undefined, JSHINT, jshintArgs),
+      spawn.bind(undefined, JSCS, jscsArgs),
+      spawn.bind(undefined, ESLINT, eslintArgs)
+    ], function (err, r) {
+      if (err) return error(err)
+      if (r.some(Boolean)) printErrors()
+    })
+  }
 
   function usePathOrFallback (rcpath, file) {
     var customPath = path.join(rcpath, file)
@@ -107,14 +148,13 @@ module.exports = function (opts) {
 
   function spawn (command, args, cb) {
     var child = cp.spawn(command, args)
-    child.on('error', error)
+    child.on('error', cb)
     child.on('close', function (code) {
-      if (code !== 0) cb(new Error('non-zero exit code: ' + code))
-      else cb(null)
+      cb(null, code)
     })
+    if (opts.stdin) process.stdin.pipe(child.stdin)
     stderrPipe(child.stdout)
     stderrPipe(child.stderr)
-    return child
   }
 
   function stderrPipe (readable) {
@@ -126,8 +166,7 @@ module.exports = function (opts) {
       })
   }
 
-  function done (err) {
-    if (!err) return
+  function printErrors () {
     if (opts.bare) {
       errors.forEach(function (str) {
         console.error(str)
@@ -138,6 +177,9 @@ module.exports = function (opts) {
     console.error('Error: Code style check failed:')
     var errMap = {}
     errors
+      .map(function (str) { // normalize stdin "filename"
+        return str.replace(/^(<text>|input)/, 'stdin')
+      })
       .filter(function (str) { // de-duplicate errors
         if (errMap[str]) return false
         errMap[str] = true

--- a/index.js
+++ b/index.js
@@ -93,7 +93,30 @@ module.exports = function standard (opts) {
 
   var eslintReporter = opts.verbose ? ESLINT_REPORTER_VERBOSE : ESLINT_REPORTER
   var eslintArgs = ['--config', ESLINT_RC, '--format', eslintReporter]
+<<<<<<< HEAD
 >>>>>>> 175eb77... Support stdin [usage: standard < file.js]
+=======
+  
+  var rcpath = opts.rcpath || DEFAULT_RCPATH
+  var jshintPath = usePathOrFallback(rcpath, JSHINT_RC)
+  var jscsPath = usePathOrFallback(rcpath, JSCS_RC)
+  var eslintPath = usePathOrFallback(rcpath, ESLINT_RC)
+
+  ignore = ignore.map(function (pattern) {
+    return new Minimatch(pattern)
+  })
+
+  glob('**/*.js', {
+    cwd: opts.cwd || process.cwd()
+  }, function (err, files) {
+    if (err) return error(err)
+    files = files.filter(function (file) {
+      return !ignore.some(function (mm) {
+        return mm.match(file)
+      })
+    })
+
+>>>>>>> d0529a6... add --rcpath option
 
   if (opts.verbose) {
     jshintArgs.push('--verbose')

--- a/lib/eslint-reporter-verbose.js
+++ b/lib/eslint-reporter-verbose.js
@@ -5,7 +5,6 @@ module.exports = function (results) {
     var messages = result.messages
     messages.forEach(function (message) {
       var msg = message.message
-      if (msg[msg.length - 1] === '.') msg = msg.substring(0, msg.length - 1)
 
       output += result.filePath
       output += ':' + message.line || 0

--- a/lib/eslint-reporter.js
+++ b/lib/eslint-reporter.js
@@ -5,7 +5,6 @@ module.exports = function (results) {
     var messages = result.messages
     messages.forEach(function (message) {
       var msg = message.message
-      if (msg[msg.length - 1] === '.') msg = msg.substring(0, msg.length - 1)
 
       output += result.filePath
       output += ':' + message.line || 0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "standard",
   "description": "JavaScript Standard Style",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "standard",
   "description": "JavaScript Standard Style",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "standard",
   "description": "JavaScript Standard Style",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": {
     "name": "Feross Aboukhadijeh",
     "email": "feross@feross.org",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "jshint": "^2.6.0",
     "minimatch": "^2.0.1",
     "minimist": "^1.1.0",
+    "run-parallel": "^1.0.0",
     "split": "^0.3.2"
   },
   "devDependencies": {
     "extend.js": "0.0.2",
     "mkdirp": "^0.5.0",
     "rimraf": "^2.2.8",
-    "run-parallel": "^1.0.0",
     "run-series": "^1.0.2"
   },
   "homepage": "https://github.com/feross/standard",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jscs": "^1.10.0",
     "jshint": "^2.6.0",
     "minimatch": "^2.0.1",
+    "minimist": "^1.1.0",
     "split": "^0.3.2"
   },
   "devDependencies": {

--- a/rc/.eslintrc
+++ b/rc/.eslintrc
@@ -126,7 +126,7 @@
         "operator-assignment": [0, "always"],
         "padded-blocks": 0,
         "quote-props": 0,
-        "quotes": [2, "single"],
+        "quotes": [2, "single", "avoid-escape"],
         "radix": 2,
         "semi": 0,
         "sort-vars": 0,

--- a/rc/.eslintrc
+++ b/rc/.eslintrc
@@ -60,7 +60,7 @@
         "no-mixed-spaces-and-tabs": [2, false],
         "no-multi-spaces": 2,
         "no-multi-str": 2,
-        "no-multiple-empty-lines": 0,
+        "no-multiple-empty-lines": [2, {"max": 1}],
         "no-native-reassign": 2,
         "no-negated-in-lhs": 2,
         "no-nested-ternary": 0,

--- a/rc/.jscsrc
+++ b/rc/.jscsrc
@@ -22,7 +22,6 @@
   "requireLineFeedAtFileEnd": true,
   "requireOperatorBeforeLineBreak": ["=", "+", "-", "/", "*", "==", "===", "!=", "!==", ">", ">=", "<", "<="],
   "requireParenthesesAroundIIFE": true,
-  "requireSpaceAfterLineComment": true,
   "requireSpaceBeforeObjectValues": true,
   "requireSpaceBetweenArguments": true,
   "requireSpacesInConditionalExpression": {

--- a/rc/.jscsrc
+++ b/rc/.jscsrc
@@ -15,7 +15,6 @@
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
   "disallowSpacesInCallExpression": true,
   "disallowSpacesInsideParentheses": true,
-  "disallowTrailingWhitespace": true,
   "esnext": true,
   "requireBlocksOnNewline": 1,
   "requireCapitalizedConstructors": true,

--- a/rc/.jscsrc
+++ b/rc/.jscsrc
@@ -42,9 +42,5 @@
   },
   "validateIndentation": 2,
   "validateLineBreaks": "LF",
-  "validateParameterSeparator": ", ",
-  "validateQuoteMarks": {
-      "mark": "'",
-      "escape": true
-  }
+  "validateParameterSeparator": ", "
 }

--- a/rc/.jscsrc
+++ b/rc/.jscsrc
@@ -15,7 +15,6 @@
   "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
   "disallowSpacesInCallExpression": true,
   "disallowSpacesInsideParentheses": true,
-  "disallowTrailingComma": true,
   "disallowTrailingWhitespace": true,
   "esnext": true,
   "requireBlocksOnNewline": 1,

--- a/rc/.jscsrc
+++ b/rc/.jscsrc
@@ -2,7 +2,6 @@
   "disallowKeywordsOnNewLine": ["else"],
   "disallowKeywords": ["with"],
   "disallowMixedSpacesAndTabs": true,
-  "disallowMultipleLineBreaks": true,
   "disallowMultipleLineStrings": true,
   "disallowMultipleVarDecl": "exceptUndefined",
   "disallowNewlineBeforeBlockStatements": true,


### PR DESCRIPTION
This PR adds a new option --rcpath (or -r for short). This allows the user to provide an alternative directory to use which could hold one or many .rc files.

example:
```bash
standard --rcpath my/custom/rules
```

- Additional logic has been added to ensure `standard` will fallback to the standard .rc files in its own rc directory if they don't exist. This allows the user to just override a single .rc file if they wish.
- An additional test function has been added which will use a custom .jshintrc file with "use strict" turned on. `standard --rcpath altrc` is then run againts the same set of git repos as before, and it "passes" only if errors come back.
- `cmd.js` has been switched to use `minimist` to handle multiple args nicely.


I've sensed a bit of a philosophical struggle on adding flags to turn on/off things for this module, and I agree that it should be opinionated. Adding this option could be a way for users to do their own thing or deviate without further complicating things. It also gives you a canned response for bikeshed issues: "use the --rcpath option if you don't like rule X."

The ulterier motive here is that this gives me a graceful way of handling Flet/semistandard#2 without it needed to be a full forked copy of this repo.
