### PR TITLE
change clone to --depth 1 in test.js

### DIFF
--- a/test.js
+++ b/test.js
@@ -46,7 +46,7 @@ mkdirp.sync(TMP)
 series(Object.keys(modules).map(function (name) {
   var url = modules[name]
   return function (cb) {
-    var args = [ 'clone', url, path.join(TMP, name) ]
+    var args = [ 'clone', '--depth', 1, url, path.join(TMP, name) ]
     // TODO: Start `git` in a way that works on Windows – PR welcome!
     spawn('git', args, {}, cb)
   }


### PR DESCRIPTION
Changing to `--depth 1` saves about 7MB of total downloading and and shaves about 5 seconds from testing time for me (downloading at 2.00 MiB/s),