### PR TITLE
Don't rely on node_modules/.bin path

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "minimist": "^1.1.0",
     "run-parallel": "^1.0.0",
     "split": "^0.3.2",
-    "uniq": "^1.0.1"
+    "uniq": "^1.0.1",
+    "which": "^1.0.8"
   },
   "devDependencies": {
     "extend.js": "0.0.2",
@@ -64,7 +65,9 @@
     "url": "git://github.com/feross/standard.git"
   },
   "scripts": {
-    "test": "node ./bin/cmd.js && node ./test.js"
+    "test": "node ./bin/cmd.js && node ./test.js",
+    "which-eslint": "which eslint",
+    "which-jscs": "which jscs"
   },
   "standard": {
     "ignore": "tmp/**"


### PR DESCRIPTION
It's unsafe to assume binaries will be installed into `node_modules/.bin`.

`npm dedupe` and npm@3 will try to move them to a higher-level `node_modules` when possible to simplify the dependency tree. [see the [npm blog](http://blog.npmjs.org/post/109921886740/a-belated-npm-weekly-3)]

Instead, let's find the location at runtime using the `PATH` that npm sets for us.

@othiym23 / @ljharb - This look right to you?
@insin - Could you test this out on Windows? Then I'll do a release.