### PR TITLE
always ignore node_modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var ESLINT_REPORTER = path.join(__dirname, 'lib', 'eslint-reporter.js')
 var ESLINT_REPORTER_VERBOSE = path.join(__dirname, 'lib', 'eslint-reporter-verbose.js')
 
 var DEFAULT_IGNORE = [
-  'node_modules/**',
+  '**/node_modules/**',
   '.git/**',
   '**/*.min.js',
   '**/bundle.js',


### PR DESCRIPTION
Since it's not that uncommon to have e.g. an examples directory (see [react](https://github.com/facebook/react/tree/master/examples/basic-commonjs)) with a `package.json`. Therefore I think it's a good idea to *always* ignore `node_modules`.