### PR TITLE
Add rule: Must throw an Error object

### DIFF
--- a/rc/.eslintrc
+++ b/rc/.eslintrc
@@ -141,6 +141,7 @@
         "no-sync": 0,
         "no-ternary": 0,
         "no-trailing-spaces": 2,
+        "no-throw-literal": 2,
         "no-undef": 2,
         "no-undef-init": 2,
         "no-undefined": 0,


### PR DESCRIPTION
The following are considered errors by `standard`:

```js
throw "error";

throw 0;

throw undefined;

throw null;
```

The following are NOT considered errors by `standard`:

```js
throw new Error();

throw new Error("error");

var e = new Error("error");
throw e;

try {
    throw new Error("error");
} catch (e) {
    throw e;
}
```