### PR TITLE
Make example run standard after tests have passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ First, install `standard`. Then, install the appropriate plugin for your editor:
       "standard": "*"
     },
     "scripts": {
-      "test": "standard && node my-normal-tests.js"
+      "test": "node my-normal-tests.js && standard"
     }
   }
   ```


### PR DESCRIPTION
Loving standard, @feross. Even the lack of semi-colons.

The only thing I found in my flow - especially switching to standard was:

I prefer to see format run AFTER my tests. This way, I'm focused on getting code to pass first and format second. 

This pull request just updates the README to reflect that personal opinion.

Sooo, this is an extremely nitpicky and mostly personal pull request, but I thought the majority might have a similar flow of programming thought. :smile_cat: