### PR TITLE
make --format work for stdin

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -31,8 +31,7 @@ if (argv.help) {
       -v, --verbose    Show error codes (so you can ignore specific rules)
           --stdin      Force processing input from stdin
           --version    Display the current version
-      -F  --format     EXPERIMENTIAL: format code using standard-format before linting
-                       (will not work with stdin)
+      -F  --format     format code using standard-format before linting
       -h, --help       Display the help and usage details
 
   Report bugs:  https://github.com/feross/standard/issues

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "debug": "^2.1.1",
     "eslint": "^0.15.0",
     "find-root": "^0.1.1",
+    "get-stdin": "^4.0.1",
     "glob": "^4.3.5",
     "jscs": "^1.10.0",
     "minimatch": "^2.0.1",
@@ -24,7 +25,8 @@
     "run-auto": "^1.0.0",
     "run-parallel": "^1.0.0",
     "split": "^0.3.2",
-    "standard-format": "^1.2.0",
+    "standard-format": "^1.3.3",
+    "string-to-stream": "^1.0.0",
     "uniq": "^1.0.1",
     "which": "^1.0.8"
   },


### PR DESCRIPTION
This PR will make stdin work when using the --format option. It will also lint the formatted version of stdin which mimics the behavior of --format on files.

All feedback welcome, thanks!