### PR TITLE
fix cwd bug when using as module

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function lintFiles (files, opts, cb) {
     // flatten nested arrays
     var files = results.reduce(function (files, result) {
       result.forEach(function (file) {
-        files.push(file)
+        files.push(path.join(opts.cwd, file))
       })
       return files
     }, [])

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "url": "git://github.com/feross/standard.git"
   },
   "scripts": {
-    "test": "node ./bin/cmd.js && node ./test.js",
+    "test": "node ./bin/cmd.js && node ./test.js && node test-as-module.js",
     "which-eslint": "which eslint"
   },
   "standard": {

--- a/test-as-module.js
+++ b/test-as-module.js
@@ -1,0 +1,6 @@
+var standard = require('./')
+
+standard.lintFiles([], {cwd: 'bin' }, function (err, result) {
+  if (err) console.error(err)
+  else console.log('errors: ' + result.errorCount)
+})


### PR DESCRIPTION
I think I found a bug when trying to use `standard` programatically... I included a little test file to illustrate my problem and also a proposed solution.