### PR TITLE
Ignore files in .gitignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,9 @@ This module saves you time in two ways:
 
 ### How do I ignore files?
 
-The paths `node_modules/`, `.git/`, `*.min.js`, `bundle.js`, and `coverage/` are automatically excluded
-when looking for `.js` files to style check.
+The paths `node_modules/**`, `*.min.js`, `bundle.js`, `coverage/**`, and hidden
+files/folders (beginning with `.`) are automatically excluded when looking for `.js` files
+to style check.
 
 Sometimes you need to ignore additional folders or specific minfied files. To do that, add
 a `standard.ignore` property to `package.json`:

--- a/index.js
+++ b/index.js
@@ -16,7 +16,6 @@ var DEFAULT_PATTERNS = [
 ]
 
 var DEFAULT_IGNORE_PATTERNS = [
-  '.git/**',
   'coverage/**',
   'node_modules/**',
   '**/*.min.js',

--- a/index.js
+++ b/index.js
@@ -17,9 +17,9 @@ var DEFAULT_PATTERNS = [
 ]
 
 var DEFAULT_IGNORE_PATTERNS = [
-  '**/node_modules/**',
   '.git/**',
   'coverage/**',
+  'node_modules/**',
   '**/*.min.js',
   '**/bundle.js'
 ]

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "dezalgo": "^1.0.1",
-    "dotignore": "^0.1.1",
     "eslint": "^0.18.0",
     "eslint-plugin-react": "^1.5.0",
     "find-root": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "dezalgo": "^1.0.1",
+    "dotignore": "^0.1.1",
     "eslint": "^0.18.0",
     "eslint-plugin-react": "^1.5.0",
     "find-root": "^0.1.1",
@@ -67,8 +68,5 @@
   },
   "scripts": {
     "test": "node ./bin/cmd.js && tape test/*.js"
-  },
-  "standard": {
-    "ignore": "tmp/**"
   }
 }


### PR DESCRIPTION
I think it makes sense to ignore the files in `.gitignore` by default. Anything that's not checked into git (generated files, `node_modules`, temporary files, etc.) shouldn't be getting linted. I don't see a downside to ignoring them. This should hopefully decrease the need for people to use the `"standard"` property of `package.json`.

Fixes #95 - support .gitignore.
Fixes #61 - support the "app node_modules pattern". Replaces PR #66.