### PR TITLE
Add section about Git pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,16 @@ git diff --name-only --cached --relative | grep '\.js$' | xargs standard
 exit $?
 ```
 
+Alternatively, [overcommit](https://github.com/brigade/overcommit) is a Git hook
+manager that includes support for running `standard` as a Git pre-commit hook.
+To enable this, add the following to your `.overcommit.yml` file:
+
+```yaml
+PreCommit:
+  Standard:
+    enabled: true
+```
+
 ## License
 
 MIT. Copyright (c) [Feross Aboukhadijeh](http://feross.org).


### PR DESCRIPTION
overcommit is a fully configurable and extendable Git hook manager that
includes out-of-the-box support for running standard as a Git pre-commit
hook.