### PR TITLE
Updated eslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "dezalgo": "^1.0.1",
-    "eslint": "^0.18.0",
+    "eslint": "^0.19.0",
     "eslint-plugin-react": "^2.1.0",
     "find-root": "^0.1.1",
     "get-stdin": "^4.0.1",


### PR DESCRIPTION
Relates to this issue https://github.com/eslint/eslint/issues/2304

Getting the following error from standard
```shell
standard: Unexpected linter output:

TypeError: Cannot read property 'type' of undefined
    at isExported (/Users/XXX/XXX/node_modules/standard/node_modules/eslint/lib/rules/no-unused-vars.js:43:27)
```