### PR TITLE
Fixed a bug in parseOpts that causes default ignore patterns to be added to original opts object

### DIFF
--- a/index.js
+++ b/index.js
@@ -112,6 +112,9 @@ function lintFiles (files, opts, cb) {
 function parseOpts (opts) {
   if (!opts) opts = {}
 
+  // Clone opts -object to make sure the original opts object is not modified
+  opts = JSON.parse(JSON.stringify(opts))
+
   if (!opts.cwd) opts.cwd = process.cwd()
 
   // Add user ignore patterns to default ignore patterns


### PR DESCRIPTION
I found this causing problems in [gulp-standard](https://github.com/emgeee/gulp-standard) where lintText -function is being used in a loop causing opts object to contain exponential times the ignore patterns slowing tasks down and eventually causing crash.