### PR TITLE
only use relative paths in ignore check. fixes #166

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function lintFiles (files, opts, cb) {
 
     if (opts._gitignore) {
       if (os.platform() === 'win32') files = files.map(toUnix)
-      files = opts._gitignore.filter(files)
+      files = toAbsolute(opts.cwd, opts._gitignore.filter(toRelative(opts.cwd, files)))
       if (os.platform() === 'win32') files = files.map(toWin32)
     }
 
@@ -172,6 +172,18 @@ function parseOpts (opts) {
   }
 
   return opts
+}
+
+function toAbsolute (cwd, files) {
+  return files.map(function (file) {
+    return path.join(cwd, file)
+  })
+}
+
+function toRelative (cwd, files) {
+  return files.map(function (file) {
+    return path.relative(cwd, file)
+  })
 }
 
 function toUnix (str) {


### PR DESCRIPTION
I have the same problem as described in #166. PR fixes that by using relative paths when running through the gitignore filter. Note that two tests are failing but I also had the same two tests fail on master.