### PR TITLE
Use https:// link for eslint tarball instead of git://

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "dezalgo": "^1.0.1",
-    "eslint": "git://github.com/eslint/eslint.git#3f5cf79d65560ed69ff29b11d85047554c4d1ae1",
+    "eslint": "https://github.com/eslint/eslint/tarball/3f5cf79d65560ed69ff29b11d85047554c4d1ae1",
     "eslint-config-standard": "3.3.0",
     "eslint-config-standard-react": "1.0.0",
     "eslint-plugin-react": "^2.1.0",


### PR DESCRIPTION
git:// tries to use ssh behind the scenes which is usually blocked by corporate networks.  https:// tends not to be so use that instead.

This prevents this sort of error:

```
npm ERR! git fetch -a origin (git://github.com/eslint/eslint.git) fatal: unable to connect to github.com:
npm ERR! git fetch -a origin (git://github.com/eslint/eslint.git) github.com[0: 192.30.252.131]: errno=Operation timed out
npm ERR! Error: Command failed: fatal: unable to connect to github.com:
npm ERR! github.com[0: 192.30.252.131]: errno=Operation timed out
```