### PR TITLE
use deglob to reconcile file list

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,12 +29,6 @@ var DEFAULT_CONFIG = {
   useEslintrc: false
 }
 
-var DEGLOB_OPTIONS = {
-  useGitIgnore: true,
-  usePackageJson: true,
-  configKey: 'standard'
-}
-
 /**
  * Lint text to enforce JavaScript Standard Style.
  *
@@ -81,7 +75,15 @@ function lintFiles (files, opts, cb) {
   if (typeof files === 'string') files = [ files ]
   if (files.length === 0) files = DEFAULT_PATTERNS
 
-  deglob(files, opts, function (err, allFiles) {
+  var deglobOpts = {
+    ignore: opts.ignore,
+    cwd: opts.cwd,
+    useGitIgnore: true,
+    usePackageJson: true,
+    configKey: 'standard'
+  }
+
+  deglob(files, deglobOpts, function (err, allFiles) {
     if (err) return cb(err)
      // undocumented – do not use (used by bin/cmd.js)
     if (opts._onFiles) opts._onFiles(allFiles)
@@ -99,7 +101,7 @@ function lintFiles (files, opts, cb) {
 
 function parseOpts (opts) {
   if (!opts) opts = {}
-  opts = extend(opts, DEGLOB_OPTIONS)
+  opts = extend(opts)
   opts._config = extend(DEFAULT_CONFIG)
   opts.configKey = 'standard'
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
+    "deglob": "^1.0.0",
     "dezalgo": "^1.0.1",
     "eslint": "0.24.1",
     "eslint-config-standard": "3.4.1",
@@ -21,13 +22,9 @@
     "eslint-plugin-react": "^2.1.0",
     "find-root": "^0.1.1",
     "get-stdin": "^4.0.1",
-    "glob": "^5.0.0",
-    "ignore": "^2.2.15",
     "minimist": "^1.1.0",
     "pkg-config": "^1.0.1",
-    "run-parallel": "^1.0.0",
     "standard-format": "^1.3.3",
-    "uniq": "^1.0.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello!

I extracted a new package, `deglob`, from the existing code in `standard`. Its goal is to take a list of glob patterns and return an array of file locations, while respecting `.gitignore` and allowing for ignore patterns via `package.json`.

I wanted to use the same ignore/gitignore behavior in `standard-format` and I also thought this behavior would be useful for other CLI tools. 

To ensure no bottleneck, I have added all collaborators of `standard` to deglob (and gave them publish access in npm).

Feedback on `deglob` itself is welcome! :)