### PR TITLE
Add Atom standard-formatter to documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,11 @@ For automatic formatting on save, install **[StandardFormat][sublime-4]**.
 
 Install **[Linter][atom-1]** and **[linter-js-standard][atom-2]**.
 
+For automatic formatting, install **[standard-formatter][atom-3]**.
+
 [atom-1]: https://atom.io/packages/linter
 [atom-2]: https://atom.io/packages/linter-js-standard
+[atom-3]: https://atom.io/packages/standard-formatter
 
 #### [Vim](http://www.vim.org/)
 


### PR DESCRIPTION
Adds a reference to standard-formatter package for Atom to go along with other editor plugin documentation.