### PR TITLE
Remove duped word from tagline message

### DIFF
--- a/options.js
+++ b/options.js
@@ -6,7 +6,7 @@ module.exports = {
   version: pkg.version,
   homepage: pkg.homepage,
   bugs: pkg.bugs.url,
-  tagline: 'Use JavaScript Standard Style',
+  tagline: 'JavaScript Standard Style',
   eslintConfig: {
     configFile: path.join(__dirname, 'rc', '.eslintrc')
   },


### PR DESCRIPTION
"Use" is added by standard-engine resulting in the following tagline being printed

```standard: Use Use JavaScript Standard Style (https://github.com/feross/standard)```