### PR TITLE
Fix "globals" property typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ cases, you can add this to `package.json`:
 ```json
 {
   "standard": {
-    "global": [ "myVar1", "myVar2" ]
+    "globals": [ "myVar1", "myVar2" ]
   }
 }
 ```


### PR DESCRIPTION
In the example package.json, the property name wasn't correct.