### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,10 @@ For automatic formatting on save, install **[StandardFormat][sublime-4]**.
 
 #### [Atom](https://atom.io)
 
-Install **[Linter][atom-1]** and **[linter-js-standard][atom-2]**.
+Install **[linter-js-standard][atom-2]**.
 
 For automatic formatting, install **[standard-formatter][atom-3]**.
 
-[atom-1]: https://atom.io/packages/linter
 [atom-2]: https://atom.io/packages/linter-js-standard
 [atom-3]: https://atom.io/packages/standard-formatter
 


### PR DESCRIPTION
`linter-js-standard` doesn't need `linter` installed beforehand as prior. [`59cbc84`](https://github.com/ricardofbarros/linter-js-standard/commit/59cbc84b6e2eb9ab3ec9aac50b77ff23d4d8c9a3)