### PR TITLE
standard should run after other test scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Search the extension registry for **["Standard Code Style"][brackets-1]**.
       "standard": "^3.0.0"
     },
     "scripts": {
-      "test": "standard && node my-tests.js"
+      "test": "node my-tests.js && standard"
     }
   }
   ```


### PR DESCRIPTION
You might want to just quickly test but you don't care about stylings for now. For example, you add a `console.log` or you add some scripts with no indentation, and then you wanna quickly run the test scripts.