### PR TITLE
Add noote about multiline ternary operator rules

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -172,6 +172,23 @@ your code.
   console.log(value)
   ```
 
+* **For the ternary operator** in a multi-line setting, place `?` and `:` on their own lines.
+
+  ```js
+  // ✓ ok
+  var location = env.development ? 'localhost' : 'www.api.com'
+
+  // ✓ ok
+  var location = env.development
+    ? 'localhost'
+    : 'www.api.com'
+
+  // ✗ avoid
+  var location = env.development ?
+    'localhost' :
+    'www.api.com'
+  ```
+
 ## Semicolons
 
 * No semicolons. (see: [1](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding), [2](http://inimino.org/%7Einimino/blog/javascript_semicolons), [3](https://www.youtube.com/watch?v=gsfbh17Ax9I))


### PR DESCRIPTION
Takes care of:

> `'?' should be placed at the beginning of the line. (operator-linebreak)`