### PR TITLE
Readme: update travis image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm][npm-image]][npm-url]
 [![downloads][downloads-image]][downloads-url]
 
-[travis-image]: https://img.shields.io/travis/feross/standard.svg?style=flat
+[travis-image]: https://travis-ci.org/feross/standard.svg?branch=master
 [travis-url]: https://travis-ci.org/feross/standard
 [npm-image]: https://img.shields.io/npm/v/standard.svg?style=flat
 [npm-url]: https://npmjs.org/package/standard


### PR DESCRIPTION
it always shows as 'invalid'.

i'm changing them to the official travis badge, which now uses shield.io's style anyway.