### PR TITLE
fix link to semicolons section

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npm install standard
 [1]: http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding
 [2]: http://inimino.org/~inimino/blog/javascript_semicolons
 [3]: https://www.youtube.com/watch?v=gsfbh17Ax9I
-[4]: RULES.md#automatic-semicolon-insertion-asi
+[4]: RULES.md#semicolons
 [5]: RULES.md#javascript-standard-style
 
 To get a better idea, take a look at


### PR DESCRIPTION
Looks like the heading to this section changed in commit https://github.com/feross/standard/commit/2932f295a638c7088bb048f9b611dda6a99633a1, so this updates the link to point to the new heading.