### PR TITLE
enhance output of clone.js

### DIFF
--- a/test/clone.js
+++ b/test/clone.js
@@ -54,9 +54,10 @@ test('test github repos that use `standard`', function (t) {
         var gitArgs = err
           ? [ 'clone', '--depth', 1, url, path.join(TMP, name) ]
           : [ 'pull' ]
-        var gitOpts = err
-          ? {}
-          : { stdio: ['inherit', 'ignore', 'inherit'], cwd: folder }
+        var gitOpts = { stdio: 'ignore' }
+        gitOpts = err
+          ? gitOpts
+          : extend(gitOpts, { cwd: folder })
         spawn(GIT, gitArgs, gitOpts, function (err) {
           if (err) {
             err.message += ' (' + name + ')'


### PR DESCRIPTION
Here are a few enhancements to `clone.js` that should help folks identify and fix lint issues in repositories.

This pull request includes:
- filter out `stdout` from the `git clone/pull` command in order to reduce noise
- add github URL to each test message. This should help jump into failing repos quickly.
- add `pass` tests for disabled repositories. This should give some visibility to disabled repositories so no one forgets them!

Here is a sample of the output after this PR (trucated a bit):
```bash
TAP version 13
# api: lintFiles
ok 1 no error while linting
ok 2 result is an object
ok 3 should be equal
# api: lintText
ok 4 no error while linting
ok 5 result is an object
ok 6 should have used single quotes
# Disabled Packages
ok 7 DISABLED: hms: broke since v5.0.0 (https://github.com/mafintosh/hms)
ok 8 DISABLED: hyperlog: broke since v5.0.0 (https://github.com/mafintosh/hyperlog)
ok 9 DISABLED: multileveldown: broke since v5.0.0 (https://github.com/mafintosh/multileveldown)
ok 10 DISABLED: node-gyp-install: broke since v5.0.0 (https://github.com/mafintosh/node-gyp-install)
ok 11 DISABLED: pbs: broke since v5.0.0 (https://github.com/mafintosh/pbs)
ok 12 DISABLED: dat-core: broke since v5.2.0 (https://github.com/maxogden/dat-core)
ok 13 DISABLED: npm: broke since v5.0.0 (https://github.com/npm/npm)
ok 14 DISABLED: docs: broke since v5.2.0 (https://github.com/npm/docs)
ok 15 DISABLED: event-bulk-attach: broke since v5.2.0 (https://github.com/yoshuawuyts/event-bulk-attach)
# test github repos that use `standard`
ok 16 har-convert (https://github.com/ahmadnassri/har-convert)
ok 17 echint (https://github.com/ahmadnassri/echint)
ok 18 forwarded-http (https://github.com/ahmadnassri/forwarded-http)
ok 19 har (https://github.com/ahmadnassri/har)
ok 56 simple-websocket (https://github.com/feross/simple-websocket)
ok 57 simple-peer (https://github.com/feross/simple-peer)
ok 58 standard-www (https://github.com/feross/standard-www)
standard: Use JavaScript Standard Style (https://github.com/feross/standard) 
  /home/icmpdev/code/standard/tmp/snazzy/index.js:96:1: Multiple blank lines not allowed. (no-multiple-empty-lines)
not ok 59 snazzy (https://github.com/feross/snazzy)
  ---
    operator: error
    expected: |-
      undefined
    actual: |-
      [Error: non-zero exit code: 1]
    at: ChildProcess.<anonymous> (/home/icmpdev/code/standard/test/clone.js:82:21)
    stack: |-
      Error: non-zero exit code: 1
          at ChildProcess.<anonymous> (/home/icmpdev/code/standard/test/clone.js:82:24)
          at emitTwo (events.js:87:13)
          at ChildProcess.emit (events.js:172:7)
          at maybeClose (internal/child_process.js:818:16)
          at Process.ChildProcess._handle.onexit (internal/child_process.js:211:5)
  ...
ok 60 torrent-discovery (https://github.com/feross/torrent-discovery)
1..140
# tests 140
# pass  139
# fail  1

npm ERR! Test failed.  See above for more details.
```