### PR TITLE
remove "?style=flat" in badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ let people know that your code is using the standard style.
 [![js-standard-style](https://cdn.rawgit.com/feross/standard/master/badge.svg)](https://github.com/feross/standard)
 ```
 
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
 ```markdown
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
+[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 ```
 
 ## Usage


### PR DESCRIPTION
#### Remove "?style=flat" in badge link, because it's unnecessary!

| style | badge |
|-----------------------|----------------------------------------------------------------------------------------|
| with "?style=flat" | [![](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)]() |
| without "?style=flat" | [![](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)]() |
