### PR TITLE
README.md: suggest installing version `*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Search the extension registry for **["Standard Code Style"][brackets-1]**.
     }
   }
   ```
+  
+  Or set the version to `"*"` to encourage using the latest version.
 
 2. Check style automatically when you run `npm test`
 


### PR DESCRIPTION
I remember that it was the recommended way in the past.

Why not anymore?