### PR TITLE
Follow Standard in Examples

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -279,13 +279,13 @@ Clever short-hands are discouraged, in favor of clear and readable expressions, 
 possible. So, while this is allowed:
 
 ```js
-;[1,2,3].forEach(bar)
+;[1, 2, 3].forEach(bar)
 ```
 
 This is much preferred:
 
 ```js
-var nums = [1,2,3]
+var nums = [1, 2, 3]
 nums.forEach(bar)
 ```
 


### PR DESCRIPTION
It's a tiny thing, but it bugs me that the examples at the very end don't follow the standard! I propose the above correction. I don't think there's anything else wrong.

Let me know what you think!