### PR TITLE
standard-format@2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-react": "^3.9.0",
     "eslint-plugin-standard": "^1.3.1",
     "standard-engine": "^2.0.4",
-    "standard-format": "^1.3.3"
+    "standard-format": "^2.1.0"
   },
   "devDependencies": {
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
`standard-format@2.1.0` is shipped with `esformatter-jsx@3` including `babylon@6`
