### PR TITLE
Correct atom package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ For automatic formatting on save, install **[StandardFormat][sublime-4]**.
 Install **[linter-js-standard][atom-1]**.
 
 For automatic formatting, install **[standard-formatter][atom-2]**.
-For snippets, install **[atom-standardjs-snippets][atom-3]**.
+For snippets, install **[standardjs-snippets][atom-3]**.
 
 [atom-1]: https://atom.io/packages/linter-js-standard
 [atom-2]: https://atom.io/packages/standard-formatter


### PR DESCRIPTION
The name of the snippets package in atom is standardjs-snippets not atom-standardjs-snippets