### PR TITLE
Improve the description of 'no semicolons'

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -227,7 +227,7 @@ your code.
   window.alert('hi');  // ✗ avoid
   ```
 
-* Never start a line with `(` or `[`. This is the only gotcha with omitting semicolons.
+* Never start a line with `(` or `[`. This is the only gotcha with omitting semicolons - standard will complain if you do this.
 
   ```js
   ;(function () {


### PR DESCRIPTION
> This is the only gotcha with omitting semicolons.

This statement seems to convey that its still a gotcha, and programmers need to keep this is mind even while using standard for code linting. However, since standard catches and flags it, its not a gotcha anymore.