### PR TITLE
Readme: document mocha support

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,19 +372,27 @@ spend your time solving! :P
 
 ### What about Web Workers?
 
-Web workers have a magic global variable called `self`. In regular JS files, `standard`
-won't let you use `self` directly, as it wants to prevent accidental use of
-`window.self`. But `standard` has no way of knowing when you are in a `worker` and
-therefore does not know when to allow usage of `self` directly.
+Add this to the top of your files:
 
-Until we figure out a better solution, we recommend adding this to the top of workers:
-
-```
-/* global self */
+```js
+/* eslint-env serviceworker */
 ```
 
 This lets `standard` (as well as humans reading your code) know that `self` is a global
 in web worker code.
+
+### What about Mocha, Jasmine, QUnit, etc?
+
+To support mocha in your test files, add this to the beginning of your test files:
+
+```js
+/* eslint-env mocha */
+```
+
+Where `mocha` can be one of `jasmine`, `qunit`, `phantomjs`, and so on. To see a full list,
+check ESLint's [specifying environments](http://eslint.org/docs/user-guide/configuring.html#specifying-environments)
+documentation. For a list of what globals are available for these environments, check
+the [globals](https://github.com/sindresorhus/globals/blob/master/globals.json) npm module.
 
 ### Is there a Git `pre-commit` hook?
 


### PR DESCRIPTION
I've also changed the service worker documentation, since eslint supports those natively.