### PR TITLE
Link to webstorm.md is broken.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ For automatic formatting, install **[vscode-standard-format][vscode-2]**.
 Both WebStorm and PhpStorm can be [configured for Standard Style][webstorm-2].
 
 [webstorm-1]: https://www.jetbrains.com/webstorm/
-[webstorm-2]: docs/webstorm.md
+[webstorm-2]: https://github.com/feross/standard/blob/master/docs/webstorm.md
 
 ### What you might do if you're clever
 


### PR DESCRIPTION
At least on http://standardjs.com/. I'm not 100% sure my fix is correct one, since it's not relative. I wanted to point out a broken link.