### PR TITLE
fix markdown formatting in RULES.md

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -40,7 +40,7 @@ your code.
   if(condition) { ... }    // ✗ avoid
   ```
 
-* **Add a space* before a function declaration's parentheses.
+* **Add a space before a function declaration's parentheses.**
 
   ```js
   function name (arg) { ... }   // ✓ ok


### PR DESCRIPTION
A previous commit broke the formatting on this line: https://github.com/feross/standard/commit/e765b91c878ee454300dc3a9d76c41472d416b0c#commitcomment-16730715