### PR TITLE
Undo config hacks added in v6.0.2 and v6.0.3

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["standard", "standard-jsx"]
+}

--- a/options.js
+++ b/options.js
@@ -5,7 +5,6 @@ var pkg = require('./package.json')
 module.exports = {
   bugs: pkg.bugs.url,
   cmd: 'standard',
-  cwd: __dirname,
   eslint: eslint,
   eslintConfig: {
     configFile: path.join(__dirname, 'eslintrc.json')

--- a/options.js
+++ b/options.js
@@ -1,26 +1,17 @@
 var eslint = require('eslint')
-var extend = require('xtend')
+var path = require('path')
 var pkg = require('./package.json')
 
-var configStandard = require('eslint-config-standard')
-var configStandardJsx = require('eslint-config-standard-jsx')
-
-var config = extend(configStandard)
-config.plugins.push.apply(config.plugins, configStandardJsx.plugins)
-
-Object.keys(configStandardJsx.rules).forEach(function (key) {
-  config.rules[key] = configStandardJsx.rules[key]
-})
-
 module.exports = {
-  eslint: eslint,
-  cmd: 'standard',
-  version: pkg.version,
-  homepage: pkg.homepage,
   bugs: pkg.bugs.url,
-  tagline: 'Use JavaScript Standard Style',
+  cmd: 'standard',
+  cwd: __dirname,
+  eslint: eslint,
   eslintConfig: {
-    baseConfig: config
+    configFile: path.join(__dirname, 'eslintrc.json')
   },
-  formatter: 'Formatting is no longer included with standard. Install it separately: "npm install -g standard-format"'
+  formatter: 'Formatting is no longer included with standard. Install it separately: "npm install -g standard-format"',
+  homepage: pkg.homepage,
+  tagline: 'Use JavaScript Standard Style',
+  version: pkg.version
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "eslint-plugin-promise": "^1.0.8",
     "eslint-plugin-react": "^5.0.1",
     "eslint-plugin-standard": "^1.3.1",
-    "standard-engine": "^3.3.0",
-    "xtend": "^4.0.1"
+    "standard-engine": "^3.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^6.0.0",


### PR DESCRIPTION
This seems like a good thing? @feross I just rebased your branch... no other changes.

>These hacks were added to deal with bugs in eslint v2.0.0:
>
>https://github.com/feross/standard/compare/v6.0.1...v6.0.3
>
>Should not be necessary now.