### PR TITLE
Update CLI usage when using glob patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,10 @@ Error: Use JavaScript Standard Style
   lib/torrent.js:950:11: Expected '===' and instead saw '=='.
 ```
 
-You can optionally pass in a directory using the glob pattern:
+You can optionally pass in a directory (or directories) using the glob pattern. Be sure to quote paths containing glob patterns so that they are expanded by standard instead of your shell:
 
 ```bash
-$ standard src/util/**/*.js
+$ standard "src/util/**/*.js" "test/**/*.js"
 ```
 
 **Note:** by default `standard` will look for all files matching the patterns: `**/*.js`, `**/*.jsx`.


### PR DESCRIPTION
Globs need to be quoted or they will be expanded by your shell (and not standard). This means that explicitly matching the default patterns (`standard **/*.js **/*.jsx`) will likely result in a different result than just relying on the defaults.