### PR TITLE
add standard-summary to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,8 @@ And run:
 $ standard --verbose | snazzy
 ```
 
-There's also [standard-tap](https://www.npmjs.com/package/standard-tap), [standard-json](https://www.npmjs.com/package/standard-json), and [standard-reporter](https://www.npmjs.com/package/standard-reporter)
+There's also [standard-tap](https://www.npmjs.com/package/standard-tap), [standard-json](https://www.npmjs.com/package/standard-json),  [standard-reporter](https://www.npmjs.com/package/standard-reporter), and
+[standard-summary](https://www.npmjs.com/package/standard-summary).
 
 ### I want to contribute to `standard`. What packages should I know about?
 


### PR DESCRIPTION
`standard-reporter` didn't quite fit my needs and [doesn't appear to be open-source](https://twitter.com/zeke/status/714689396163887105), so I whipped up this alternative module for summarizing standard output with error counts. Here's what the output looks like for the [electron refactor](https://github.com/atom/electron/pull/4909) I'm working on:

```
> cat test/fixture.txt | node index.js

5966   Extra semicolon
1615   Missing space before function parentheses
318    Strings must use singlequote
55     Return statement should not contain assignment
38     Expected { after 'if' condition
24     Expected '===' and instead saw '=='
23     Missing '()' invoking a constructor
17     Block must not be padded by blank lines
16     Unexpected trailing comma
13     Multiple spaces found before '+='
12     The '__proto__' property is deprecated
10     Expected space(s) after "catch"
9      Multiple spaces found before '='
8      Gratuitous parentheses around expression
8      Expected '!==' and instead saw '!='
7      More than 1 blank line not allowed
```

https://github.com/zeke/standard-summary#readme

