### PR TITLE
Update pre-commit hook regex and exit logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,8 +407,8 @@ Funny you should ask!
 ```sh
 #!/bin/sh
 # Ensure all javascript files staged for commit pass standard code style
-git diff --name-only --cached --relative | grep '\.js$' | xargs standard
-exit $?
+git diff --name-only --cached --relative | grep '\.jsx\?$' | xargs standard
+if [ $? -ne 0 ]; then exit 1; fi
 ```
 
 Alternatively, [overcommit](https://github.com/brigade/overcommit) is a Git hook


### PR DESCRIPTION
Standard defaults to matching all files with the extension .js or .jsx
Update pre-commit hook to match files with both extensions.
Update pre-commit hook to only exit upon failure of command.