### PR TITLE
Fix Webstorm double quoting

### DIFF
--- a/docs/webstorm.md
+++ b/docs/webstorm.md
@@ -10,6 +10,7 @@ config settings directory.
   <code_scheme name="Standard">
     <JSCodeStyleSettings>
       <option name="USE_SEMICOLON_AFTER_STATEMENT" value="false" />
+      <option name="USE_DOUBLE_QUOTES" value="false" />
       <option name="SPACES_WITHIN_OBJECT_LITERAL_BRACES" value="true" />
     </JSCodeStyleSettings>
     <XML>


### PR DESCRIPTION
Prevents Webstorm to format generated code with double quotes, e.g.:

`import Bar from 'bar'`

instead of

`import Bar from "bar"`