### PR TITLE
Use eslint v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,3 @@ language: node_js
 node_js:
   - '4'
   - 'node'
-  - '0.12'
-  - '0.10'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
-    "eslint": "~2.10.2",
+    "eslint": "~3.0.1",
     "eslint-config-standard": "5.3.1",
     "eslint-config-standard-jsx": "1.2.1",
     "eslint-plugin-promise": "^1.0.8",


### PR DESCRIPTION
For #564

BREAKING: Drop support for node < 4 (this was a decision made by the ESLint team)