### PR TITLE
Improve standard v8 behavior on legacy versions of Node

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
 
-var opts = require('../options')
-require('standard-engine').cli(opts)
+if (process.version.match(/v(\d+)\./)[1] < 4) {
+  console.error('standard: Node v4 or greater is required. `standard` did not run.')
+} else {
+  var opts = require('../options')
+  require('standard-engine').cli(opts)
+}
+

--- a/package.json
+++ b/package.json
@@ -62,11 +62,11 @@
     "url": "git://github.com/feross/standard.git"
   },
   "scripts": {
-    "update-authors": "./bin/update-authors.sh",
     "test": "./bin/cmd.js --verbose && tape test/*.js",
     "test-disabled": "npm test -- --disabled",
     "test-offline": "npm test -- --offline",
     "test-offline-quick": "npm test -- --offline --quick",
-    "test-quick": "npm test -- --quick"
+    "test-quick": "npm test -- --quick",
+    "update-authors": "./bin/update-authors.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "standard-packages": "^3.1.9",
     "tape": "^4.6.0"
   },
+  "engines": {
+    "node": ">=4"
+  },
   "homepage": "http://standardjs.com",
   "keywords": [
     "JavaScript Standard Style",


### PR DESCRIPTION
On Node versions earlier than v4, standard throws an error like this:

```
> standard

/usr/local/lib/node_modules/standard/node_modules/eslint/node_modules/strip-bom/index.js:2
module.exports = x => {
                    ^
SyntaxError: Unexpected token >
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/usr/local/lib/node_modules/standard/node_modules/eslint/lib/config/config-file.js:23:16)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
```

Let's skip running `standard` on Node <4 and print a warning to stderr. I also added an install-time warning using the `package.json` "engines" field to warn on Node <4.
