### PR TITLE
Recommend `/* global */` comment over `window.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ npm install standard
 - **Space after function name** `function name (arg) { ... }`
 - Always use `===` instead of `==` – but `obj == null` is allowed to check `null || undefined`.
 - Always handle the node.js `err` function parameter
-- Always prefix browser globals with `window` – except `document` and `navigator` are okay
+- Declare browser globals with `/* global */` comment at top of file
   - Prevents accidental use of poorly-named browser globals like `open`, `length`,
     `event`, and `name`.
+  - Example: `/* global alert, prompt */`
+  - Exceptions are: `window`, `document`, and `navigator`
 - **And [more goodness][5]** – *give `standard` a try today!*
 
 [1]: http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding

--- a/RULES.md
+++ b/RULES.md
@@ -149,8 +149,20 @@ your code.
   })
   ```
 
-* **Always prefix browser globals** with `window.`.<br>
-  Exceptions are: `document`, `console` and `navigator`.
+* **Declare browser globals** with a `/* global */` comment.<br>
+  Exceptions are: `window`, `document` and `navigator`.<br>
+  Prevents accidental use of poorly-named browser globals like `open`, `length`,
+  `event`, and `name`.
+
+  ```js
+  /* global alert, prompt */
+
+  alert('hi')
+  prompt('ok?')
+  ```
+
+  Explicitly referencing the function or property on `window` is okay too, though
+  such code will not run in a Worker which uses `self` instead of `window`.
 
   ```js
   window.alert('hi')   // ✓ ok


### PR DESCRIPTION
I think using a comment at the top to make global dependencies explicit
is the nicest solution.

Context: https://twitter.com/feross/status/774766522124218368