### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
-    "eslint": "~3.3.1",
+    "eslint": "~3.5.0",
     "eslint-config-standard": "6.0.1",
     "eslint-config-standard-jsx": "3.0.1",
     "eslint-plugin-promise": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "eslint": "~3.3.1",
-    "eslint-config-standard": "6.0.0",
     "eslint-config-standard-jsx": "3.0.0",
+    "eslint-config-standard": "6.0.1",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-react": "^6.0.0",
     "eslint-plugin-standard": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "eslint": "~3.3.1",
-    "eslint-config-standard-jsx": "3.0.0",
     "eslint-config-standard": "6.0.1",
+    "eslint-config-standard-jsx": "3.0.1",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-react": "^6.0.0",
     "eslint-plugin-standard": "^2.0.0",


### PR DESCRIPTION
Upgrade eslint from 3.3.1 to 3.5.0, which adds 5-10 new rules that are fixable with `--fix`.

There were also new rule additions. I will create separate issues for the ones that make sense.