### PR TITLE
update vscode editor extension part

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,9 +243,9 @@ Search the extension registry for **["Standard Code Style"][brackets-1]**.
 
 #### [Visual Studio Code](https://code.visualstudio.com/)
 
-Install **[vscode-standardjs][vscode-1]**.
+Install [vscode-standardjs][vscode-1].
 
-For automatic formatting, install **[vscode-standard-format][vscode-2]**. For React
+For automatic formatting, use [vscode-standardjs][vscode-1] when you're running standard v8.x.x, or you can use **[vscode-standard-format][vscode-2]** which might be deprecated later. For React
 snippets, install **[vscode-react-standard][vscode-3]**.
 
 [vscode-1]: https://marketplace.visualstudio.com/items/chenxsan.vscode-standardjs

--- a/README.md
+++ b/README.md
@@ -243,10 +243,9 @@ Search the extension registry for **["Standard Code Style"][brackets-1]**.
 
 #### [Visual Studio Code](https://code.visualstudio.com/)
 
-Install [vscode-standardjs][vscode-1].
+Install [vscode-standardjs][vscode-1](includes support for automatic formatting).
 
-For automatic formatting, use [vscode-standardjs][vscode-1] when you're running standard v8.x.x, or you can use **[vscode-standard-format][vscode-2]** which might be deprecated later. For React
-snippets, install **[vscode-react-standard][vscode-3]**.
+For React snippets, install **[vscode-react-standard][vscode-3]**.
 
 [vscode-1]: https://marketplace.visualstudio.com/items/chenxsan.vscode-standardjs
 [vscode-2]: https://marketplace.visualstudio.com/items/chenxsan.vscode-standard-format


### PR DESCRIPTION
I have forked a new [vscode-standardjs](https://github.com/chenxsan/vscode-standardjs) from [vscode-eslint](https://github.com/Microsoft/vscode-eslint) to support standard v8.x.x.