### PR TITLE
Webstorm instructions should reference eslint-config-standard-jsx

### DIFF
--- a/docs/webstorm.md
+++ b/docs/webstorm.md
@@ -1,11 +1,10 @@
 # [WebStorm/PhpStorm][webstorm-1] configuration for Standard Style
 
-1. Turn off your IDE
+1. Close your IDE.
 2. [Figure out where your configuration lives][webstorm-2] (_IDE Settings_ section)
-3. Navigate to `your-config-dir/codestyles`. If this directory doesn't exist, create it in the WebStorm
-config settings directory
+3. Navigate to `your-config-dir/codestyles`. If this directory doesn't exist,
+   create it in the WebStorm config settings directory
 4. Create a `Standard.xml` file:
-
   ```xml
     <code_scheme name="Standard">
       <JSCodeStyleSettings>
@@ -33,32 +32,28 @@ config settings directory
   ```
 
 5. You may install dependencies and config globally or locally and with support of ES7 or without it
-  * **Local** install **with** support of ES7
-    * `npm install standard eslint-config-standard eslint-plugin-standard eslint-plugin-promise babel-eslint`
-    * `echo '{"extends": ["standard"], "parser": "babel-eslint"}' > .eslintrc` (be warned: it overrides an existing file)
-  * **Local** install **without** support of ES7
-    * `npm install standard eslint-config-standard eslint-plugin-standard eslint-plugin-promise`
-    * `echo '{"extends": ["standard"]}' > .eslintrc`
-  * **Global** install **with** support of ES7
-      * `npm install -g standard eslint-config-standard eslint-plugin-standard eslint-plugin-promise babel-eslint`
-      * `echo '{"extends": ["standard"], "parser": "babel-eslint"}' > ~/.eslintrc` (be warned: it overrides an existing
-  * **Global** install **without** support of ES7
-    * `npm install -g standard eslint-config-standard eslint-plugin-standard eslint-plugin-promise`
-    * `echo '{"extends": ["standard"]}' > ~/.eslintrc`
+  - **Local** install:
+    - `npm install --save-dev eslint-config-standard eslint-config-standard-jsx eslint-plugin-promise eslint-plugin-react eslint-plugin-standard`
+    - `echo '{"extends": ["standard", "standard-jsx"]}' > .eslintrc`
+  - **Global** install:
+    - `npm install --global eslint-config-standard eslint-config-standard-jsx eslint-plugin-promise eslint-plugin-react eslint-plugin-standard`
+    - `echo '{"extends": ["standard", "standard-jsx"]}' > ~/.eslintrc`
 
-  If you choose global install, the first command may require you to use `sudo`. If it does - it means that you do not have permission to write to the directories that npm uses to store global packages. `Standard` will work, but if you would like to fix it - [here is one of many articles of how to do it][npm-article]
-  
-  Second command will override an existing `.eslintrc` file if you have one, so be aware
-  
-  For packages to be added to your package.json file run install commands with -S flag (to add them to dependency section) or with -D flag (to add them to devDependency section)
-6. Fire up the IDE and open a _Settings_/_Preferences_ screen (choose between project and default settings accordingly to your preference)
+  Be aware: The second command above will overwrite an existing `.eslintrc` if one exists.
+
+  If you choose global install, the first command may require you to use `sudo`. If
+  it does require sudo, that means you do not have permission to write to the
+  directories that npm uses to store global packages. `Standard` will work, but if
+  you would like to fix it, [read this article][npm-article].
+
+6. Start up the IDE and open a _Settings_/_Preferences_ screen (choose between project and default settings accordingly to your preference)
 7. Under `Editor > Code Style > JavaScript` change `Scheme` to `Standard`
 8. Under `Editor > Inspections > JavaScript > Code style issues` untick `Unterminated statement`
 9. Under `Languages & Frameworks > JavaScript > Code Quality Tools > ESLint` just select `Enable`. If you didn't install `ESLint` before and you don't have it in your dependencies - that's all. If you do - be sure to use `ESLint package` of the same version as current version of `standard` is using. Or just remove your old one - you probably won't need it anymore
 
 ---
 
-If you're a Webstorm/PhpStorm users, [vote for `standard` to be one of the default styles][webstorm-3]
+If you're a Webstorm or PhpStorm user, [vote for `standard` to be one of the default styles][webstorm-3]
 built into the app.
 
 [npm-article]: https://docs.npmjs.com/getting-started/fixing-npm-permissions


### PR DESCRIPTION
Fixes: #650.

The Webstorm instructions don't tell users to install [eslint-config-standard-jsx](https://github.com/feross/eslint-config-standard-jsx). That's fine, but they're not getting the full set of rules that `standard` includes for JSX.