### PR TITLE
Dependencies: Use ~ instead of ^.

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "eslint": "~3.6.0",
     "eslint-config-standard": "6.2.0",
     "eslint-config-standard-jsx": "3.2.0",
-    "eslint-plugin-promise": "^2.0.0",
-    "eslint-plugin-react": "^6.0.0",
-    "eslint-plugin-standard": "^2.0.0",
-    "standard-engine": "^5.0.0"
+    "eslint-plugin-promise": "~2.0.0",
+    "eslint-plugin-react": "~6.4.1",
+    "eslint-plugin-standard": "~2.0.1",
+    "standard-engine": "~5.1.0"
   },
   "devDependencies": {
     "babel-eslint": "^7.0.0",


### PR DESCRIPTION
Fixes: https://github.com/feross/standard/issues/654

I think one improvement to the situation is to switch to ~ instead of
^. This is slightly more conservative, and would have prevented the
breakage described in the above issue. We use ~ already for ESLint
since minor versions are more likely to introduce incompatibilities
than patch versions.