### PR TITLE
8.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 8.4.0 - 2016-10-10
+
+- Update ESLint from 3.6.x to 3.7.x.
+- 5 additional rules are now fixable with `standard --fix`!
+- Use more conservative semver ranges [#654](https://github.com/feross/standard/issues/654)
+
 ## 8.3.0 - 2016-09-29
 
 The last release (`8.2.0`) added ES7 support. This release (`8.3.0`) adds ES8

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint": "~3.7.1",
     "eslint-config-standard": "6.2.0",
     "eslint-config-standard-jsx": "3.2.0",
-    "eslint-plugin-promise": "~2.0.0",
+    "eslint-plugin-promise": "~3.0.0",
     "eslint-plugin-react": "~6.4.1",
     "eslint-plugin-standard": "~2.0.1",
     "standard-engine": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/feross/standard/issues"
   },
   "dependencies": {
-    "eslint": "~3.6.0",
+    "eslint": "~3.7.1",
     "eslint-config-standard": "6.2.0",
     "eslint-config-standard-jsx": "3.2.0",
     "eslint-plugin-promise": "~2.0.0",


### PR DESCRIPTION
- Update ESLint from 3.6.x to 3.7.x.
- 5 additional rules are now fixable with `standard --fix`!
- Use more conservative semver ranges