### PR TITLE
Remove broken link to semicolon blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ npm install standard
 - **2 spaces** – for indentation
 - **Single quotes for strings** – except to avoid escaping
 - **No unused variables** – this one catches *tons* of bugs!
-- **No semicolons** – [It's][1] [fine.][2] [Really!][3]
+- **No semicolons** – [It's fine.][1] [Really!][2]
 - **Never start a line with `(`, `[`, or `` ` ``**
   - This is the **only** gotcha with omitting semicolons – *automatically checked for you!*
-  - [More details][4]
+  - [More details][3]
 - **Space after keywords** `if (condition) { ... }`
 - **Space after function name** `function name (arg) { ... }`
 - Always use `===` instead of `==` – but `obj == null` is allowed to check `null || undefined`.
@@ -47,13 +47,12 @@ npm install standard
 - Always prefix browser globals with `window` – except `document` and `navigator` are okay
   - Prevents accidental use of poorly-named browser globals like `open`, `length`,
     `event`, and `name`.
-- **And [more goodness][5]** – *give `standard` a try today!*
+- **And [more goodness][4]** – *give `standard` a try today!*
 
 [1]: http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding
-[2]: http://inimino.org/~inimino/blog/javascript_semicolons
-[3]: https://www.youtube.com/watch?v=gsfbh17Ax9I
-[4]: RULES.md#semicolons
-[5]: RULES.md#javascript-standard-style
+[2]: https://www.youtube.com/watch?v=gsfbh17Ax9I
+[3]: RULES.md#semicolons
+[4]: RULES.md#javascript-standard-style
 
 To get a better idea, take a look at
 [a sample file](https://github.com/feross/bittorrent-dht/blob/master/client.js) written


### PR DESCRIPTION
[http://inimino.org/~inimino/blog/javascript_semicolons](http://inimino.org/~inimino/blog/javascript_semicolons) is liked to in the readme but no longer works. I removed the link.

Thanks for the great project!