### PR TITLE
Added --save-dev to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This module saves you (and others!) time in two ways:
 Install with:
 
 ```
-npm install standard
+npm install standard --save-dev
 ```
 
 ### The Rules


### PR DESCRIPTION
I think it would make sense to add the `--save-dev` flag, since this would mean `standard` is installed when people clone and `npm install` a project. Since one advantage is that teams have a common base, this seems to be a typical use case.