### PR TITLE
Ignore misc package files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,9 @@
+test/
 tmp/
+bin/update-authors.sh
+.travis.yml
 badge.png
 badge.svg
+CONTRIBUTING.md
 sticker.png
 sticker.svg


### PR DESCRIPTION
Usually I'm against this kind of hyper-optimizing. But unlike most
modules, the tests aren't really very useful documentation about how
`standard` works. We have README.md and RULES.md for that.