### PR TITLE
Add the word IRC to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ The `callback` will be called with an `Error` and `results` object (same as abov
 
 Contributions are welcome! Check out the [issues](https://github.com/feross/standard/issues) or the [PRs](https://github.com/feross/standard/pulls), and make your own if you want something that you don't see there.
 
-Join other contributors on IRC in `#standard` on freenode to chat!
+Want to chat? Join contributors on IRC in the `#standard` channel on freenode.
 
 Here are some important packages in the `standard` ecosystem:
 

--- a/README.md
+++ b/README.md
@@ -676,7 +676,7 @@ The `callback` will be called with an `Error` and `results` object (same as abov
 
 Contributions are welcome! Check out the [issues](https://github.com/feross/standard/issues) or the [PRs](https://github.com/feross/standard/pulls), and make your own if you want something that you don't see there.
 
-Join other contributors in `#standard` on freenode to chat!
+Join other contributors on IRC in `#standard` on freenode to chat!
 
 Here are some important packages in the `standard` ecosystem:
 


### PR DESCRIPTION
To help people (like me) who's searching the README for the word IRC to see if there's a mention of an IRC channel.

Feel free to reject or reword, but it's a true story 😉 I was searching the readme for `IRC`, but couldn't find it. So I assumed there wasn't an official IRC channel. So thought this change would help others in the same situation 😄 