### PR TITLE
Print version when running

### DIFF
--- a/options.js
+++ b/options.js
@@ -10,6 +10,6 @@ module.exports = {
     configFile: path.join(__dirname, 'eslintrc.json')
   },
   homepage: pkg.homepage,
-  tagline: 'Use JavaScript Standard Style',
+  tagline: 'Use JavaScript Standard Style ' + pkg.version,
   version: pkg.version
 }


### PR DESCRIPTION
Printing the version helps when debugging issues in a team or when
running multiple standard versions.

You instantly see which version of standard is running right now.

---

![image](https://cloud.githubusercontent.com/assets/298166/24820737/e00bbc68-1bea-11e7-82b1-a7f95d260ec9.png)

---

no proposal written as it was a fast drive-by-change :)