### PR TITLE
Recommend w0rp/ale over syntastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ autocmd bufwritepost *.js silent !standard --fix %
 set autoread
 ```
 
-Other linters you can try are [neomake][vim-2] and [syntastic][vim-3], both of which have built-in support for Standard (though configuration may be necessary).
+Alternative plugins to consider include [neomake][vim-2] and [syntastic][vim-3], both of which have built-in support for `standard` (though configuration may be necessary).
 
 [vim-1]: https://github.com/w0rp/ale
 [vim-2]: https://github.com/neomake/neomake

--- a/README.md
+++ b/README.md
@@ -258,11 +258,7 @@ For JS snippets, install: **[vscode-standardjs-snippets][vscode-2]**. For React 
 
 ### Vim
 
-Install **[Syntastic][vim-1]** and add this line to `.vimrc`:
-
-```vim
-let g:syntastic_javascript_checkers = ['standard']
-```
+Install **[ale][vim-1]**.
 
 For automatic formatting on save, add these lines to `.vimrc`:
 
@@ -271,7 +267,7 @@ autocmd bufwritepost *.js silent !standard --fix %
 set autoread
 ```
 
-[vim-1]: https://github.com/scrooloose/syntastic
+[vim-1]: https://github.com/w0rp/ale
 
 ### Emacs
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,11 @@ autocmd bufwritepost *.js silent !standard --fix %
 set autoread
 ```
 
+Other linters you can try are [neomake][vim-2] and [syntastic][vim-3], both of which have built-in support for Standard (though configuration may be necessary).
+
 [vim-1]: https://github.com/w0rp/ale
+[vim-2]: https://github.com/neomake/neomake
+[vim-3]: https://github.com/vim-syntastic/syntastic
 
 ### Emacs
 


### PR DESCRIPTION
https://github.com/w0rp/ale has:

- built-in support for standard (as long as `node_modules/.bin/standard` [exists](
https://github.com/w0rp/ale/blob/4b0f3257ddf4303a00979cd1171dd449bd3b9ed5/ale_linters/javascript/standard.vim)), nothing to configure.

- supports neovim.

- runs asynchronously, so it never makes your vim halt up.
