### PR TITLE
add alternative atom linter plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,12 +239,19 @@ For automatic formatting on save, install **[StandardFormat][sublime-4]**.
 
 Install **[linter-js-standard][atom-1]**.
 
+Alternatively, you can install **[linter-js-standard-engine][atom-4]**. Instead of
+bundling a version of `standard` it will automatically use the version installed
+in your current project. It will also work out of the box with other linters based
+on **[standard-engine][atom-5]**.
+
 For automatic formatting, install **[standard-formatter][atom-2]**. For snippets,
 install **[standardjs-snippets][atom-3]**.
 
 [atom-1]: https://atom.io/packages/linter-js-standard
 [atom-2]: https://atom.io/packages/standard-formatter
 [atom-3]: https://atom.io/packages/standardjs-snippets
+[atom-4]: https://atom.io/packages/linter-js-standard-engine
+[atom-5]: https://github.com/Flet/standard-engine
 
 ### Visual Studio Code
 


### PR DESCRIPTION
@novemberborn and I have been working on an alternative atom plugin for standard and other standard-engine compatible linters. We thought that it might be of use to others as well, and thus wanted to add a note here :-)

The main difference to the already mentioned plugin is that it is not bundling the code of the linters into the plugin, but will use a compatible linter installed in the given project. Another benefit is that it, aside from supporting a few selected standard-engine derived linters out of the box, also supports arbitrary other implementations through project specific configuration.

The plugin was started out of frustration with the excisting plugin giving different errors or warnings than running `standard` in the shell because of versions drifting apart. This plugin solves that problem.

I hope you will consider adding it to your README.